### PR TITLE
feat: use job enums in log schemas

### DIFF
--- a/packages/contracts/src/schemas/logs.ts
+++ b/packages/contracts/src/schemas/logs.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { JobTypeSchema, JobStatusSchema } from '../enums/job';
 
 // Logs Query Schema
 export const GetLogsQuerySchema = z.object({
@@ -13,8 +14,8 @@ export const GetLogsQuerySchema = z.object({
 // Log Item Schema
 export const LogItemSchema = z.object({
   id: z.string().uuid(),
-  type: z.string(),
-  status: z.string(),
+  type: JobTypeSchema,
+  status: JobStatusSchema,
   tenantId: z.string().uuid(),
   userId: z.string().uuid(),
   userName: z.string(),
@@ -41,7 +42,7 @@ export const GetLogsResponseSchema = z.object({
 
 // Job Create Request Schema
 export const JobCreateRequestSchema = z.object({
-  type: z.enum(['EMBED', 'DECODE']),
+  type: JobTypeSchema,
   srcImagePath: z.string().min(1),
   params: z.record(z.string(), z.any()).optional(),
 });


### PR DESCRIPTION
## Summary
- import shared job enums in log schemas
- use `JobTypeSchema` and `JobStatusSchema` for log item and job creation request types

## Testing
- `pnpm -F @acme/contracts build`
- `pnpm test` *(fails: Couldn't find any `pages` or `app` directory)*


------
https://chatgpt.com/codex/tasks/task_e_68a6a8b272b48328b361f1e33067d6fa