### PR TITLE
chore(web): narrow tailwind content paths

### DIFF
--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -5,10 +5,7 @@ const config: Config = {
   darkMode: ['class'],
   content: [
     './app/**/*.{js,ts,jsx,tsx,mdx}',
-    './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',
-    './src/**/*.{js,ts,jsx,tsx,mdx}',
-    '../../packages/*/src/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- restrict Tailwind CSS content scanning to app and component directories in web app
- rebuild Tailwind CSS to confirm no extraneous files

## Testing
- `pnpm -F web lint` *(fails: Unexpected any and unused vars across app)*
- `pnpm test` *(fails: Next.js couldn't find pages or app directory at repo root)*
- `pnpm --filter @acme/web exec tailwindcss -i styles/globals.css -o /tmp/tailwind.css -c tailwind.config.ts --minify`

------
https://chatgpt.com/codex/tasks/task_e_68a6a865db088328a6b541f48cd62630