### PR TITLE
refactor: use shared job enums

### DIFF
--- a/apps/web/app/job/page.tsx
+++ b/apps/web/app/job/page.tsx
@@ -25,6 +25,7 @@ import type {
   CreateJobRequest,
   GetJobsResponse,
 } from '@acme/contracts';
+import { JOB_STATUS } from '@acme/contracts';
 import { toast } from 'sonner';
 import { handleUIError } from '@/lib/errors/uiHandler';
 
@@ -58,7 +59,8 @@ export default function JobPage() {
         query.state.data?.pages.flatMap((page: GetJobsResponse) => page.jobs) ??
         [];
       const hasActiveJobs = jobs.some(
-        (job) => job.status === 'PENDING' || job.status === 'RUNNING'
+        (job) =>
+          job.status === JOB_STATUS.PENDING || job.status === JOB_STATUS.RUNNING
       );
       return hasActiveJobs ? 5000 : false;
     },

--- a/apps/web/components/JobStatusCard.tsx
+++ b/apps/web/components/JobStatusCard.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
-import { JobStatus } from '@prisma/client';
+import { JobStatus, JOB_STATUS } from '@acme/contracts';
 
 interface JobStatusCardProps {
   jobId: string;
@@ -17,10 +17,10 @@ const statusMap: Record<
   JobStatus,
   { label: string; variant: 'default' | 'secondary' | 'destructive' | 'outline' }
 > = {
-  [JobStatus.PENDING]: { label: 'Pending', variant: 'outline' },
-  [JobStatus.RUNNING]: { label: 'Running', variant: 'secondary' },
-  [JobStatus.DONE]: { label: 'Completed', variant: 'default' },
-  [JobStatus.ERROR]: { label: 'Failed', variant: 'destructive' },
+  [JOB_STATUS.PENDING]: { label: 'Pending', variant: 'outline' },
+  [JOB_STATUS.RUNNING]: { label: 'Running', variant: 'secondary' },
+  [JOB_STATUS.DONE]: { label: 'Completed', variant: 'default' },
+  [JOB_STATUS.ERROR]: { label: 'Failed', variant: 'destructive' },
 };
 
 const JobStatusCard: React.FC<JobStatusCardProps> = ({ jobId, status, progress, createdAt }) => {
@@ -33,7 +33,7 @@ const JobStatusCard: React.FC<JobStatusCardProps> = ({ jobId, status, progress, 
         <Badge variant={variant}>{label}</Badge>
       </CardHeader>
       <CardContent>
-        {status === JobStatus.RUNNING && progress !== undefined && (
+        {status === JOB_STATUS.RUNNING && progress !== undefined && (
           <div className="mt-2">
             <Progress value={progress} className="w-full" />
             <p className="text-xs text-muted-foreground mt-1">{progress}% complete</p>

--- a/apps/web/components/LogTable.tsx
+++ b/apps/web/components/LogTable.tsx
@@ -11,7 +11,12 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
-import { Job, JobStatus } from '@prisma/client';
+import {
+  JobListItem as Job,
+  JobStatus,
+  JOB_TYPE,
+  JOB_STATUS,
+} from '@acme/contracts';
 import { format } from 'date-fns';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { ImageCell } from '@/components/common/image-cell';
@@ -26,13 +31,13 @@ const LogTable: React.FC<LogTableProps> = ({ jobs = [] }) => {
 
   const getStatusVariant = (status: JobStatus) => {
     switch (status) {
-      case JobStatus.DONE:
+      case JOB_STATUS.DONE:
         return 'default';
-      case JobStatus.RUNNING:
+      case JOB_STATUS.RUNNING:
         return 'secondary';
-      case JobStatus.ERROR:
+      case JOB_STATUS.ERROR:
         return 'destructive';
-      case JobStatus.PENDING:
+      case JOB_STATUS.PENDING:
       default:
         return 'outline';
     }
@@ -46,7 +51,7 @@ const LogTable: React.FC<LogTableProps> = ({ jobs = [] }) => {
 
   const getWatermarkText = (job: Job) => {
     if (
-      job.type === 'EMBED' &&
+      job.type === JOB_TYPE.EMBED &&
       job.params &&
       typeof job.params === 'object' &&
       job.params !== null
@@ -57,7 +62,7 @@ const LogTable: React.FC<LogTableProps> = ({ jobs = [] }) => {
       }
     }
     if (
-      job.type === 'DECODE' &&
+      job.type === JOB_TYPE.DECODE &&
       job.result &&
       typeof job.result === 'object' &&
       job.result !== null
@@ -72,7 +77,7 @@ const LogTable: React.FC<LogTableProps> = ({ jobs = [] }) => {
 
   const getModeStrength = (job: Job) => {
     if (
-      job.type === 'EMBED' &&
+      job.type === JOB_TYPE.EMBED &&
       job.params &&
       typeof job.params === 'object' &&
       job.params !== null
@@ -84,7 +89,7 @@ const LogTable: React.FC<LogTableProps> = ({ jobs = [] }) => {
       }
     }
     if (
-      job.type === 'DECODE' &&
+      job.type === JOB_TYPE.DECODE &&
       job.result &&
       typeof job.result === 'object' &&
       job.result !== null


### PR DESCRIPTION
## Summary
- import job enums from @acme/contracts instead of @prisma/client
- compare job statuses using JOB_STATUS constants

## Testing
- `pnpm build` (fails: Failed to fetch Inter font from Google Fonts)
- `pnpm test` (fails: Couldn't find any `pages` or `app` directory)


------
https://chatgpt.com/codex/tasks/task_e_68a6ad056ffc832880bafe11d1922e10