### PR TITLE
refactor: handle unknown errors in pubsub

### DIFF
--- a/apps/web/lib/pubsub.ts
+++ b/apps/web/lib/pubsub.ts
@@ -23,8 +23,12 @@ export async function publishJob(message: { jobId: string; tenantId: string }) {
   try {
     const messageId = await topic.publishMessage({ json: message });
     console.log(`Message ${messageId} published.`);
-  } catch (error: any) {
-    console.error(`Received error while publishing: ${error.message}`);
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      console.error(`Received error while publishing: ${error.message}`);
+    } else {
+      console.error('Received error while publishing.');
+    }
     throw error;
   }
 }


### PR DESCRIPTION
## Summary
- use `unknown` in Pub/Sub publishJob error handler and guard with `instanceof`

## Testing
- `pnpm test` *(fails: Couldn't find any `pages` or `app` directory)*
- `pnpm lint` *(fails: Couldn't find any `pages` or `app` directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e516e5a88328a616af891a683887