### PR TITLE
Use DecodeRequest type in decode API route

### DIFF
--- a/apps/web/app/api/v1/decode/route.ts
+++ b/apps/web/app/api/v1/decode/route.ts
@@ -1,11 +1,12 @@
 import { createRouteHandler } from '@/lib/ts-rest/next-handler';
 import { contract, JOB_TYPE, JOB_STATUS } from '@acme/contracts';
+import type { DecodeRequest } from '@acme/contracts';
 import { jobsRepo } from '@acme/db';
 import { getSessionInfo } from '@/lib/utils/apiAuth';
 import { execSync } from 'child_process';
 import { downloadFile } from '@/lib/gcs/storage.server';
 
-export const POST = createRouteHandler(contract.decode, async ({ body }: { body: any }) => {
+export const POST = createRouteHandler(contract.decode, async ({ body }: { body: DecodeRequest }) => {
   try {
     // Get session information
     const { tenantId, userId, userName } = await getSessionInfo();


### PR DESCRIPTION
## Summary
- import DecodeRequest type for decode API route
- type decode route handler request body

## Testing
- `pnpm lint --file app/api/v1/decode/route.ts` *(fails: Unexpected any in other files)*
- `pnpm test` *(fails: Couldn't find any `pages` or `app` directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e51dd6dc83289581c6507e98f5b7